### PR TITLE
Fix doesn't work with Ruby < 2.4

### DIFF
--- a/lib/xipio/middleware.rb
+++ b/lib/xipio/middleware.rb
@@ -5,7 +5,7 @@ module Xipio
     end
 
     def call(env)
-      tld_length = env['HTTP_HOST'].match?(/\.xip\.io(:\d{1,5})?\z/) ? 6 : 1
+      tld_length = /\.xip\.io(:\d{1,5})?\z/ =~ env['HTTP_HOST'] ? 6 : 1
       ActionDispatch::Http::URL.tld_length = tld_length
       @app.call(env)
     end


### PR DESCRIPTION
# Issue
Closes #5

# Changes
- Use `=~` instead of `match?` for investigating `env['HTTP_HOST']`

# Note
Ruby 2.4 introduced `String#match?` method which returns `true/false` instead of the match data and it would be better to use the method if we do not support Ruby < 2.4.  Another solution is just using `/.../ =~ env['HTTP_POST']`.

See https://github.com/fphilipe/xipio/pull/4#discussion_r151167542